### PR TITLE
GPT-1: Button redirect to create new store on empty store listings

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -328,6 +328,27 @@ h1 {
   display: contents;
 }
 
+.new-store-redirect {
+  grid-column-start: 2; 
+  padding: 0;
+  margin-top: -0.85em;
+  border: none;
+  background: none;
+  justify-self: start;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.new-store-redirect svg {
+  margin-right: 0.25rem;
+  vertical-align: middle; 
+}
+
+.new-store-redirect:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+}
+
 .discount-group label {
   grid-column: 1;
   align-self: center;
@@ -640,6 +661,11 @@ h1 {
 
   .add-form .big-chain-group [type="checkbox"] {
     transform: scale(1.4);
+  }
+
+  .new-store-redirect {
+    grid-column-start: auto;
+    font-size: 16px;
   }
 }
 

--- a/src/pages/CreateNewItem.tsx
+++ b/src/pages/CreateNewItem.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import DOMPurify from "dompurify";
 import Swal from 'sweetalert2'
 import { isSafeUrl } from "../utils/isSafeUrl";
@@ -9,6 +10,8 @@ import StoresDropdownSelect from "../custom-dropdown-select/StoresDropdownSelect
 import { generateClient } from "aws-amplify/data";
 import type { Schema } from "../../amplify/data/resource";
 import Scanner from "../components/Scanner";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 
 const client = generateClient<Schema>();
 
@@ -29,6 +32,8 @@ const initialItemInputs: ItemInputs = {
 const CreateNewItem: React.FC = () => {
   const [inputs, setInputs] = useState<ItemInputs>(initialItemInputs);
   const [selectedStore, setSelectedStore] = useState<Store>();
+
+  const navigate = useNavigate();
 
   // Generic change handler for text, number, and checkbox fields
   const handleChange = (
@@ -170,6 +175,20 @@ const CreateNewItem: React.FC = () => {
             onSubmit={handleSubmit}
             method="POST"
           >
+
+          <label htmlFor="storeName">Store Name<span className="required-form-item">*</span></label>
+          <StoresDropdownSelect 
+            value={selectedStore}
+            onChange={(store: Store) => handleStoreSelect(store)}
+          />
+          <button
+            type="button"
+            className="new-store-redirect"
+            onClick={() => navigate("/create-new-store")}
+          >
+          <FontAwesomeIcon icon={faCircleInfo} />
+          Store not listed? Add here.
+          </button>
             
           <label htmlFor="barcode">Barcode (recommended)</label>
           <Scanner
@@ -249,12 +268,6 @@ const CreateNewItem: React.FC = () => {
               onChange={handleChange}
               autoComplete="off"
               maxLength={2000}
-            />
-
-            <label htmlFor="storeName">Store Name<span className="required-form-item">*</span></label>
-            <StoresDropdownSelect 
-              value={selectedStore}
-              onChange={(store: Store) => handleStoreSelect(store)}
             />
 
             <div className="discount-group">


### PR DESCRIPTION
changed message to "Store not listed? Add here." to prevent line wrapping on smaller screens

desktop
<img width="715" height="276" alt="image" src="https://github.com/user-attachments/assets/1cce4d68-9dd7-426e-bbca-dbd1ab2fba0b" />


mobile
<img width="380" height="333" alt="image" src="https://github.com/user-attachments/assets/21e4f3c1-7689-4d24-a87d-8440f06d04d6" />
